### PR TITLE
refactor: optimize rules and redesign options

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ it will generate below css：
 ```css
 /* layer: shortcuts */
 .scrollbar::-webkit-scrollbar{width:var(--scrollbar-width);height:var(--scrollbar-height);}
-.scrollbar{overflow:auto;scrollbar-color:var(--scrollbar-thumb) var(--scrollbar-track);--scrollbar-track:#f5f5f5;--scrollbar-thumb:#ddd;--scrollbar-width:8px;--scrollbar-height:8px;--scrollbar-track-radius:4px;--scrollbar-thumb-radius:4px;}
+.scrollbar{overflow:auto;--scrollbar-track:#f5f5f5;--scrollbar-thumb:#ddd;--scrollbar-width:8px;--scrollbar-height:8px;--scrollbar-track-radius:4px;--scrollbar-thumb-radius:4px;}
 .scrollbar-rounded::-webkit-scrollbar-thumb{border-radius:var(--scrollbar-thumb-radius);}
 .scrollbar-rounded::-webkit-scrollbar-track{border-radius:var(--scrollbar-track-radius);}
 .scrollbar::-webkit-scrollbar-thumb{background-color:var(--scrollbar-thumb);}
@@ -96,10 +96,10 @@ export default defineConfig({
 |`scrollbarThumbRadius`|`4px`|default scrollbar thumb radius|
 |`scrollbarTrackColor`|`#f5f5f5`|default scrollbar track background color|
 |`scrollbarThumbColor`|`#ddd`|default scrollbar thumb background color|
-|`numberToUnit`|``value => `${value / 4}rem` ``| number to unit
 |`varPrefix`|`''`|the css variable prefix of this preset|
-|`prefix`|`''`|Apply prefix to all utilities and shortcuts|
-|`noCompatible`|`'true'`|if `false`, it use `scrollbar-width` and `scrollbar-color`，work in Firefox, but `scrollbar-h`, `scrollbar-w` and `scrollbar-radius` will not work |
+|`compatible`|`false`|if `true`, use `scrollbar-width` / `scrollbar-color` for Firefox compatibility. In this mode, `scrollbar-h`, `scrollbar-w` and `scrollbar-radius` may not work as expected |
+
+`numberToUnit` and preset-level `prefix` are deprecated and removed in this PR.
 
 for example
 
@@ -107,22 +107,7 @@ for example
 <div class="scrollbar scrollbar-w-4">
 ```
 
-if we use default options，`scrollbar-w-4` will generate `--scrollbar-width: 1rem`
-
-if we set custom `numberToUnit`：
-
-```ts
-export default defineConfig({
-  presets: [
-    presetUno(),
-    presetScrollbar({
-      numberToUnit: value => `${value}px`,
-    }),
-  ],
-})
-```
-
-will generate `--scrollbar-width: 4px`
+`scrollbar-w-4` now follows UnoCSS built-in length parsing and generates `--scrollbar-width: 1rem`.
 
 ## Utilities
 
@@ -132,9 +117,9 @@ will generate `--scrollbar-width: 4px`
 
 ```css
 .scrollbar-thin {
-  scrollbar-width: thin; // if noCompatible is true, remove this line
-  --un-scrollbar-width: 8px;
-  --un-scrollbar-height: 8px;
+  scrollbar-width: thin; // only generated when compatible is true
+  --scrollbar-width: 8px;
+  --scrollbar-height: 8px;
 }
 ```
 
@@ -162,9 +147,13 @@ Make thumb and track have rounded corners
 
 set track or thumb background color
 
+`scrollbar-(track|thumb)-(op|opacity)-<percent>`
+
+set track or thumb color opacity variable
+
 ### size
 
-`scrollbar-(radius|w|h|track-radius|thumb-radius)-(\d+?)([a-zA-Z]*?)`
+`scrollbar-(radius|w|h|track-radius|thumb-radius)-<length>`
 
 |type|description|
 |--|--|
@@ -174,20 +163,15 @@ set track or thumb background color
 |track-radius|set track radius|
 |thumb-radius|set thumb radius|
 
-**Attention，**if it ends with number，the preset will use numberToUnit to generate length with number as params，Otherwise it will use the captured length information directly
+**Attention，**the length parsing follows UnoCSS built-in behavior. Numeric values (for example `4`) are converted to rem units, and explicit units (for example `4px`, `4rem`) are kept as-is.
 
 for example：
 - `scrollbar-w-4` will be `--scrollbar-width: 1rem`
 - `scrollbar-w-4px` will be `--scrollbar-width: 4px`
 - `scrollbar-w-4rem` will be `--scrollbar-width: 4rem`
 
-::: warning
-if set `noCompatible` value `false`，it not work
-:::
-
-## other
-
-base [starter-ts](https://github.com/antfu/starter-ts)
+> warning
+> when `compatible` is `true`, `scrollbar-w`, `scrollbar-h`, and `scrollbar-radius` may not work in compatible engines.
 
 ## License
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -41,7 +41,7 @@ export default defineConfig({
 ```css
 /* layer: shortcuts */
 .scrollbar::-webkit-scrollbar{width:var(--scrollbar-width);height:var(--scrollbar-height);}
-.scrollbar{overflow:auto;scrollbar-color:var(--scrollbar-thumb) var(--scrollbar-track);--scrollbar-track:#f5f5f5;--scrollbar-thumb:#ddd;--scrollbar-width:8px;--scrollbar-height:8px;--scrollbar-track-radius:4px;--scrollbar-thumb-radius:4px;}
+.scrollbar{overflow:auto;--scrollbar-track:#f5f5f5;--scrollbar-thumb:#ddd;--scrollbar-width:8px;--scrollbar-height:8px;--scrollbar-track-radius:4px;--scrollbar-thumb-radius:4px;}
 .scrollbar-rounded::-webkit-scrollbar-thumb{border-radius:var(--scrollbar-thumb-radius);}
 .scrollbar-rounded::-webkit-scrollbar-track{border-radius:var(--scrollbar-track-radius);}
 .scrollbar::-webkit-scrollbar-thumb{background-color:var(--scrollbar-thumb);}
@@ -96,10 +96,10 @@ export default defineConfig({
 |`scrollbarThumbRadius`|`4px`|默认的滚动条滑块的圆角|
 |`scrollbarTrackColor`|`#f5f5f5`|默认的滚动条轨迹的背景色|
 |`scrollbarThumbColor`|`#ddd`|默认的滚动条滑块的背景色|
-|`numberToUnit`|``value => `${value / 4}rem` ``|捕获到的数字转化成单位的方法|
 |`varPrefix`|`''`|该预设生成的`css`变量的前缀|
-|`prefix`|`''`|该预设生成的shortcuts加上前缀|
-|`noCompatible`|`'true'`|如果为 `false` 的话 会使用 `scrollbar-width` 和 `scrollbar-color` 这两个规则，能够在Firefox上兼容, 但是`scrollbar-h`、`scrollbar-w` 以及 `scrollbar-raidus` 会失效 |
+|`compatible`|`false`|如果为 `true` 会启用 `scrollbar-width` 和 `scrollbar-color` 以兼容 Firefox；该模式下 `scrollbar-h`、`scrollbar-w` 和 `scrollbar-radius` 可能无法按预期生效 |
+
+该 PR 中，`numberToUnit` 和预设级 `prefix` 已废弃并移除。
 
 举个例子
 
@@ -107,22 +107,7 @@ export default defineConfig({
 <div class="scrollbar scrollbar-w-4">
 ```
 
-如果你使用默认的配置，`scrollbar-w-4` 将会转化成 `--scrollbar-width: 1rem`
-
-而如果你自定义 `numberToUnit` 项：
-
-```ts
-export default defineConfig({
-  presets: [
-    presetUno(),
-    presetScrollbar({
-      numberToUnit: value => `${value}px`,
-    }),
-  ],
-})
-```
-
-将转化成 `--scrollbar-width: 4px`
+`scrollbar-w-4` 现在遵循 UnoCSS 内建的长度解析规则，生成 `--scrollbar-width: 1rem`。
 
 ## 规则
 
@@ -132,9 +117,9 @@ export default defineConfig({
 
 ```css
 .scrollbar-thin {
-  scrollbar-width: thin; // 如果 noCompatible 为 true, 则不会生成该行
-  --un-scrollbar-width: 8px;
-  --un-scrollbar-height: 8px;
+  scrollbar-width: thin; // 仅在 compatible 为 true 时生成
+  --scrollbar-width: 8px;
+  --scrollbar-height: 8px;
 }
 ```
 
@@ -156,15 +141,19 @@ export default defineConfig({
 
 使滚动条有圆角
 
-### 颜色
+### color
 
 `scrollbar-(track|thumb)-color-<color>`
 
 设置轨迹或滑块的背景色
 
+`scrollbar-(track|thumb)-(op|opacity)-<percent>`
+
+设置轨迹或滑块的透明度变量
+
 ### size
 
-`scrollbar-(radius|w|h|track-radius|thumb-radius)-(\d+?)([a-zA-Z]*?)`
+`scrollbar-(radius|w|h|track-radius|thumb-radius)-<length>`
 
 |对应key|说明|
 |--|--|
@@ -174,7 +163,7 @@ export default defineConfig({
 |track-radius|设置轨迹圆角|
 |thumb-radius|设置滑块圆角|
 
-> **注意**如果以数字结尾，则会通过 `numberToUnit` 转化成带有单位的长度，反之直接生成对应的单位长度。
+> **注意**长度解析遵循 UnoCSS 内建规则：纯数字（如 `4`）会按 rem 规则转换，带单位（如 `4px`、`4rem`）会原样保留。
 
 > **注意**想要设置滚动条的圆角，必须先使用 `scrollbar-rounded`
 
@@ -183,9 +172,9 @@ export default defineConfig({
 - `scrollbar-w-4px` -> `--scrollbar-width: 4px`
 - `scrollbar-w-4rem` -> `--scrollbar-width: 4rem`
 
-## other
+> warning
+> 当 `compatible` 为 `true` 时，`scrollbar-w`、`scrollbar-h` 和 `scrollbar-radius` 可能无法在兼容模式下生效。
 
-base [starter-ts](https://github.com/antfu/starter-ts)
 
 ## License
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,3 +1,7 @@
+shellEmulator: true
+
+trustPolicy: no-downgrade
+
 packages:
   - playground
   - examples/*

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,19 +1,6 @@
-/* eslint-disable regexp/no-useless-lazy */
-import type { Preset } from 'unocss'
-import { colorResolver, handler } from '@unocss/preset-mini/utils'
-
-const defaultOption: Required<PresetScrollbarDefaultOption> = {
-  scrollbarWidth: '8px',
-  scrollbarHeight: '8px',
-  scrollbarTrackRadius: '4px',
-  scrollbarThumbRadius: '4px',
-  scrollbarTrackColor: '#f5f5f5',
-  scrollbarThumbColor: '#ddd',
-  varPrefix: '',
-  prefix: '',
-  numberToUnit: value => `${value / 4}rem`,
-  noCompatible: true,
-}
+import type { Theme } from '@unocss/preset-mini'
+import type { Preset, Rule } from 'unocss'
+import { colorResolver, handler as h } from '@unocss/preset-mini/utils'
 
 export interface PresetScrollbarDefaultOption {
   /**
@@ -47,35 +34,29 @@ export interface PresetScrollbarDefaultOption {
    */
   scrollbarThumbColor?: string
   /**
-   * Apply prefix to all utilities and shortcuts
-   */
-  prefix?: string | string[]
-  /**
    * css variable prefix
    * @default ''
    */
   varPrefix?: string
-  /**
-   * convert number to unit
-   * @default value => `${value / 4}rem`
-   * @example
-   * numberToUnit: value => `${value / 4}rem`
-   * p-4 => padding: 1rem
-   * p-4px => padding: 4px
-   *
-   * @example
-   * numberToUnit: value => `${value}rpx`
-   * p-4 => padding: 4rpx
-   */
-  numberToUnit?: (value: number) => string
 
   /**
-   * if false will use scrollbar-color and scrollbar-width, rounded and scrollbar-w, scrollbar-h and scrollbar-radius will not work
-   * if true, won't have any effect in Firefox
+   * if true will use scrollbar-color and scrollbar-width, rounded and scrollbar-w, scrollbar-h and scrollbar-radius will not work
+   * if false, won't have any effect in Firefox
    *
-   * @default true
+   * @default false
    */
-  noCompatible?: boolean
+  compatible?: boolean
+}
+
+const defaultOption: Required<PresetScrollbarDefaultOption> = {
+  scrollbarWidth: '8px',
+  scrollbarHeight: '8px',
+  scrollbarTrackRadius: '4px',
+  scrollbarThumbRadius: '4px',
+  scrollbarTrackColor: '#f5f5f5',
+  scrollbarThumbColor: '#ddd',
+  varPrefix: '',
+  compatible: true,
 }
 
 const customRules = {
@@ -86,24 +67,33 @@ const customRules = {
   'thumb-radius': ['thumb-radius'],
 }
 
-const numberVarRegex = new RegExp(`^scrollbar-(${Object.keys(customRules).join('|')})-(\\d+?)([a-zA-Z]*?)$`)
-
-export function presetScrollbar(option?: PresetScrollbarDefaultOption): Preset {
+export function presetScrollbar(option: PresetScrollbarDefaultOption = {}): Preset<Theme> {
   const config = {
     ...defaultOption,
     ...option,
   }
-
-  function resolveVar(name: string) {
-    const prefix = config.varPrefix
-    return `--${prefix ? `${prefix}-` : ''}scrollbar-${name}`
-  }
-
+  const resolveVar = (name: string) => `--${config.varPrefix ? `${config.varPrefix}-` : ''}scrollbar-${name}`
   const variantsRE = /^(scrollbar(-track|-thumb)?):.+$/
+
+  const compatRules: Rule<Theme>[] = config.compatible
+    ? [
+        [
+          /^scrollbar-color-(.+)$/,
+          ([_, s]) => {
+            // when use scrollbar-color, ::-webkit-scrollbar styling is disabled.
+            // https://developer.mozilla.org/en-US/docs/Web/CSS/::-webkit-scrollbar
+            return {
+              'scrollbar-color': h.bracket.cssvar.auto.fraction.rem(s),
+            }
+          },
+        ],
+        ['scrollbar-width-auto', { 'scrollbar-width': 'auto' }],
+        ['scrollbar-width-thin', { 'scrollbar-width': 'thin' }],
+      ]
+    : []
 
   return {
     name: 'unocss-preset-scrollbar',
-    prefix: config.prefix,
     shortcuts: [
       [
         'scrollbar',
@@ -160,73 +150,56 @@ export function presetScrollbar(option?: PresetScrollbarDefaultOption): Preset {
       },
     ],
     rules: [
+      ...compatRules,
+      ['scrollbar-width-none', { 'scrollbar-width': 'none' }],
+      ['hidden', { display: 'none' }],
       [
-        /^scrollbar-color-(.+)$/,
-        ([_, prop]) => {
-          if (config.noCompatible)
-            return
-
-          // when use scrollbar-color, ::-webkit-scrollbar styling is disabled.
-          // https://developer.mozilla.org/en-US/docs/Web/CSS/::-webkit-scrollbar
-          return {
-            'scrollbar-color': handler.bracket.cssvar.auto.fraction.rem(prop),
-          }
-        },
-      ],
-      [
-        /^scrollbar-width-(auto|thin|none)/,
-        ([_, prop]) => {
-          const res: Record<string, string> = {}
-          if (!config.noCompatible || prop === 'none')
-            res['scrollbar-width'] = prop
-          return res
-        },
-      ],
-      [
-        /^scrollbar-custom-property$/,
-        ([_]) => ({
+        'scrollbar-custom-property',
+        {
           [resolveVar('track')]: config.scrollbarTrackColor,
           [resolveVar('thumb')]: config.scrollbarThumbColor,
           [resolveVar('width')]: config.scrollbarWidth,
           [resolveVar('height')]: config.scrollbarHeight,
           [resolveVar('track-radius')]: config.scrollbarTrackRadius,
           [resolveVar('thumb-radius')]: config.scrollbarThumbRadius,
-        }),
+        },
+      ],
+
+      [
+        /^scrollbar-(thumb|track)-color-(.+)$/,
+        (match, ctx) => {
+          const [, type] = match
+          return colorResolver(resolveVar(type), `scrollbar-${type}`)(['', match[2]], ctx)
+        },
+        { autocomplete: 'scrollbar-(thumb|track)-color-$colors' },
       ],
       [
-        /^scrollbar-thumb-color-(.+)$/,
-        colorResolver(resolveVar('thumb'), 'scrollbar-thumb'),
-        { autocomplete: 'scrollbar-thumb-color-$colors' },
+        /^scrollbar-(thumb|track)-op(?:acity)?-?(.+)$/,
+        ([, type, opacity]) => ({ [`${resolveVar(type)}-opacity`]: h.bracket.percent.cssvar(opacity) }),
+        { autocomplete: 'scrollbar-(thumb|track)-(op|opacity)-<percent>' },
       ],
+
       [
-        /^scrollbar-track-color-(.+)$/,
-        colorResolver(resolveVar('track'), 'scrollbar-track'),
-        { autocomplete: 'scrollbar-track-color-$colors' },
-      ],
-      [
-        /^scrollbar-(width|height|background-color|border-radius)-(\[var.+\])$/,
+        /^scrollbar-(width|height|background-color|border-radius)-(.+)$/,
         ([_, prop, value]) => {
           return {
-            [`${prop}`]: handler.bracket(value),
+            [`${prop}`]: h.bracket.cssvar(value),
           }
         },
       ],
+
       [
-        numberVarRegex,
-        ([_, type, value, unit]) => {
-          const val = unit ? value + unit : config.numberToUnit(Number.parseInt(value))
-          const vars = customRules[type as keyof typeof customRules]
-            .map(v => resolveVar(v))
-          return vars.reduce((acc: any, v) => {
-            acc[v] = val
+        new RegExp(`^scrollbar-(${Object.keys(customRules).join('|')})-(.+)$`),
+        ([_, type, value]) => {
+          const val = h.bracket.cssvar.numberWithUnit.px.rem(value)
+          const vars = customRules[type as keyof typeof customRules].map(resolveVar)
+
+          return vars.reduce((acc: any, k) => {
+            acc[k] = val
             return acc
           }, {})
         },
         { autocomplete: `scrollbar-(${Object.keys(customRules).join('|')})-<num>` },
-      ],
-      [
-        'hidden',
-        { display: 'none' },
       ],
     ],
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -191,7 +191,7 @@ export function presetScrollbar(option: PresetScrollbarDefaultOption = {}): Pres
       [
         new RegExp(`^scrollbar-(${Object.keys(customRules).join('|')})-(.+)$`),
         ([_, type, value]) => {
-          const val = h.bracket.cssvar.numberWithUnit.px.rem(value)
+          const val = h.bracket.cssvar.numberWithUnit.rem(value)
           const vars = customRules[type as keyof typeof customRules].map(resolveVar)
 
           return vars.reduce((acc: any, k) => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -56,7 +56,7 @@ const defaultOption: Required<PresetScrollbarDefaultOption> = {
   scrollbarTrackColor: '#f5f5f5',
   scrollbarThumbColor: '#ddd',
   varPrefix: '',
-  compatible: true,
+  compatible: false,
 }
 
 const customRules = {

--- a/test/__snapshots__/index-compatible.test.ts.snap
+++ b/test/__snapshots__/index-compatible.test.ts.snap
@@ -2,7 +2,7 @@
 
 exports[`scrollbar (compatible) > scrollbar-auto 1`] = `
 "/* layer: shortcuts */
-.scrollbar{--scrollbar-track:#f5f5f5;--scrollbar-thumb:#ddd;--scrollbar-width:8px;--scrollbar-height:8px;--scrollbar-track-radius:4px;--scrollbar-thumb-radius:4px;overflow:auto;}
+.scrollbar{scrollbar-color:var(--scrollbar-thumb) var(--scrollbar-track);scrollbar-width:auto;--scrollbar-track:#f5f5f5;--scrollbar-thumb:#ddd;--scrollbar-width:8px;--scrollbar-height:8px;--scrollbar-track-radius:4px;--scrollbar-thumb-radius:4px;overflow:auto;}
 .scrollbar::-webkit-scrollbar{width:var(--scrollbar-width);height:var(--scrollbar-height);}
 .scrollbar::-webkit-scrollbar-thumb{background-color:var(--scrollbar-thumb);}
 .scrollbar::-webkit-scrollbar-track{background-color:var(--scrollbar-track);}"
@@ -10,9 +10,9 @@ exports[`scrollbar (compatible) > scrollbar-auto 1`] = `
 
 exports[`scrollbar (compatible) > scrollbar-none 1`] = `
 "/* layer: shortcuts */
+.scrollbar{scrollbar-color:var(--scrollbar-thumb) var(--scrollbar-track);scrollbar-width:auto;--scrollbar-track:#f5f5f5;--scrollbar-thumb:#ddd;--scrollbar-width:8px;--scrollbar-height:8px;--scrollbar-track-radius:4px;--scrollbar-thumb-radius:4px;overflow:auto;}
 .scrollbar-none{scrollbar-width:none;}
 .scrollbar-none::-webkit-scrollbar{display:none;}
-.scrollbar{--scrollbar-track:#f5f5f5;--scrollbar-thumb:#ddd;--scrollbar-width:8px;--scrollbar-height:8px;--scrollbar-track-radius:4px;--scrollbar-thumb-radius:4px;overflow:auto;}
 .scrollbar::-webkit-scrollbar{width:var(--scrollbar-width);height:var(--scrollbar-height);}
 .scrollbar::-webkit-scrollbar-thumb{background-color:var(--scrollbar-thumb);}
 .scrollbar::-webkit-scrollbar-track{background-color:var(--scrollbar-track);}"
@@ -20,9 +20,9 @@ exports[`scrollbar (compatible) > scrollbar-none 1`] = `
 
 exports[`scrollbar (compatible) > scrollbar-thin 1`] = `
 "/* layer: shortcuts */
-.scrollbar{--scrollbar-track:#f5f5f5;--scrollbar-thumb:#ddd;--scrollbar-width:8px;--scrollbar-height:8px;--scrollbar-track-radius:4px;--scrollbar-thumb-radius:4px;overflow:auto;}
+.scrollbar{scrollbar-color:var(--scrollbar-thumb) var(--scrollbar-track);scrollbar-width:auto;--scrollbar-track:#f5f5f5;--scrollbar-thumb:#ddd;--scrollbar-width:8px;--scrollbar-height:8px;--scrollbar-track-radius:4px;--scrollbar-thumb-radius:4px;overflow:auto;}
+.scrollbar-thin{scrollbar-width:thin;--scrollbar-width:8px;--scrollbar-height:8px;}
 .scrollbar::-webkit-scrollbar{width:var(--scrollbar-width);height:var(--scrollbar-height);}
 .scrollbar::-webkit-scrollbar-thumb{background-color:var(--scrollbar-thumb);}
-.scrollbar::-webkit-scrollbar-track{background-color:var(--scrollbar-track);}
-.scrollbar-thin{--scrollbar-width:8px;--scrollbar-height:8px;}"
+.scrollbar::-webkit-scrollbar-track{background-color:var(--scrollbar-track);}"
 `;

--- a/test/__snapshots__/index-compatible.test.ts.snap
+++ b/test/__snapshots__/index-compatible.test.ts.snap
@@ -2,7 +2,7 @@
 
 exports[`scrollbar (compatible) > scrollbar-auto 1`] = `
 "/* layer: shortcuts */
-.scrollbar{scrollbar-color:var(--scrollbar-thumb) var(--scrollbar-track);scrollbar-width:auto;--scrollbar-track:#f5f5f5;--scrollbar-thumb:#ddd;--scrollbar-width:8px;--scrollbar-height:8px;--scrollbar-track-radius:4px;--scrollbar-thumb-radius:4px;overflow:auto;}
+.scrollbar{--scrollbar-track:#f5f5f5;--scrollbar-thumb:#ddd;--scrollbar-width:8px;--scrollbar-height:8px;--scrollbar-track-radius:4px;--scrollbar-thumb-radius:4px;overflow:auto;}
 .scrollbar::-webkit-scrollbar{width:var(--scrollbar-width);height:var(--scrollbar-height);}
 .scrollbar::-webkit-scrollbar-thumb{background-color:var(--scrollbar-thumb);}
 .scrollbar::-webkit-scrollbar-track{background-color:var(--scrollbar-track);}"
@@ -10,19 +10,19 @@ exports[`scrollbar (compatible) > scrollbar-auto 1`] = `
 
 exports[`scrollbar (compatible) > scrollbar-none 1`] = `
 "/* layer: shortcuts */
-.scrollbar{scrollbar-color:var(--scrollbar-thumb) var(--scrollbar-track);scrollbar-width:auto;--scrollbar-track:#f5f5f5;--scrollbar-thumb:#ddd;--scrollbar-width:8px;--scrollbar-height:8px;--scrollbar-track-radius:4px;--scrollbar-thumb-radius:4px;overflow:auto;}
 .scrollbar-none{scrollbar-width:none;}
+.scrollbar-none::-webkit-scrollbar{display:none;}
+.scrollbar{--scrollbar-track:#f5f5f5;--scrollbar-thumb:#ddd;--scrollbar-width:8px;--scrollbar-height:8px;--scrollbar-track-radius:4px;--scrollbar-thumb-radius:4px;overflow:auto;}
 .scrollbar::-webkit-scrollbar{width:var(--scrollbar-width);height:var(--scrollbar-height);}
 .scrollbar::-webkit-scrollbar-thumb{background-color:var(--scrollbar-thumb);}
-.scrollbar::-webkit-scrollbar-track{background-color:var(--scrollbar-track);}
-.scrollbar-none::-webkit-scrollbar{display:none;}"
+.scrollbar::-webkit-scrollbar-track{background-color:var(--scrollbar-track);}"
 `;
 
 exports[`scrollbar (compatible) > scrollbar-thin 1`] = `
 "/* layer: shortcuts */
-.scrollbar{scrollbar-color:var(--scrollbar-thumb) var(--scrollbar-track);scrollbar-width:auto;--scrollbar-track:#f5f5f5;--scrollbar-thumb:#ddd;--scrollbar-width:8px;--scrollbar-height:8px;--scrollbar-track-radius:4px;--scrollbar-thumb-radius:4px;overflow:auto;}
-.scrollbar-thin{scrollbar-width:thin;--scrollbar-width:8px;--scrollbar-height:8px;}
+.scrollbar{--scrollbar-track:#f5f5f5;--scrollbar-thumb:#ddd;--scrollbar-width:8px;--scrollbar-height:8px;--scrollbar-track-radius:4px;--scrollbar-thumb-radius:4px;overflow:auto;}
 .scrollbar::-webkit-scrollbar{width:var(--scrollbar-width);height:var(--scrollbar-height);}
 .scrollbar::-webkit-scrollbar-thumb{background-color:var(--scrollbar-thumb);}
-.scrollbar::-webkit-scrollbar-track{background-color:var(--scrollbar-track);}"
+.scrollbar::-webkit-scrollbar-track{background-color:var(--scrollbar-track);}
+.scrollbar-thin{--scrollbar-width:8px;--scrollbar-height:8px;}"
 `;

--- a/test/__snapshots__/index.test.ts.snap
+++ b/test/__snapshots__/index.test.ts.snap
@@ -2,7 +2,7 @@
 
 exports[`scrollbar > presetWind3 prefix 1`] = `
 "/* layer: shortcuts */
-.scrollbar{scrollbar-color:var(--scrollbar-thumb) var(--scrollbar-track);scrollbar-width:auto;--scrollbar-track:#f5f5f5;--scrollbar-thumb:#ddd;--scrollbar-width:8px;--scrollbar-height:8px;--scrollbar-track-radius:4px;--scrollbar-thumb-radius:4px;overflow:auto;}
+.scrollbar{--scrollbar-track:#f5f5f5;--scrollbar-thumb:#ddd;--scrollbar-width:8px;--scrollbar-height:8px;--scrollbar-track-radius:4px;--scrollbar-thumb-radius:4px;overflow:auto;}
 .scrollbar::-webkit-scrollbar{width:var(--scrollbar-width);height:var(--scrollbar-height);}
 .scrollbar::-webkit-scrollbar-thumb{background-color:var(--scrollbar-thumb);}
 .scrollbar::-webkit-scrollbar-track{background-color:var(--scrollbar-track);}"
@@ -10,7 +10,7 @@ exports[`scrollbar > presetWind3 prefix 1`] = `
 
 exports[`scrollbar > scrollbar 1`] = `
 "/* layer: shortcuts */
-.scrollbar{scrollbar-color:var(--scrollbar-thumb) var(--scrollbar-track);scrollbar-width:auto;--scrollbar-track:#f5f5f5;--scrollbar-thumb:#ddd;--scrollbar-width:8px;--scrollbar-height:8px;--scrollbar-track-radius:4px;--scrollbar-thumb-radius:4px;overflow:auto;}
+.scrollbar{--scrollbar-track:#f5f5f5;--scrollbar-thumb:#ddd;--scrollbar-width:8px;--scrollbar-height:8px;--scrollbar-track-radius:4px;--scrollbar-thumb-radius:4px;overflow:auto;}
 .scrollbar::-webkit-scrollbar{width:var(--scrollbar-width);height:var(--scrollbar-height);}
 .scrollbar::-webkit-scrollbar-thumb{background-color:var(--scrollbar-thumb);}
 .scrollbar::-webkit-scrollbar-track{background-color:var(--scrollbar-track);}
@@ -28,7 +28,7 @@ exports[`scrollbar > scrollbar custom unit 1`] = `
 
 exports[`scrollbar > should work in atributify mode 1`] = `
 "/* layer: shortcuts */
-[scrollbar~="\\~"]{scrollbar-color:var(--scrollbar-thumb) var(--scrollbar-track);scrollbar-width:auto;--scrollbar-track:#f5f5f5;--scrollbar-thumb:#ddd;--scrollbar-width:8px;--scrollbar-height:8px;--scrollbar-track-radius:4px;--scrollbar-thumb-radius:4px;overflow:auto;}
+[scrollbar~="\\~"]{--scrollbar-track:#f5f5f5;--scrollbar-thumb:#ddd;--scrollbar-width:8px;--scrollbar-height:8px;--scrollbar-track-radius:4px;--scrollbar-thumb-radius:4px;overflow:auto;}
 [scrollbar~="\\~"]::-webkit-scrollbar{width:var(--scrollbar-width);height:var(--scrollbar-height);}
 [scrollbar~="\\~"]::-webkit-scrollbar-thumb{background-color:var(--scrollbar-thumb);}
 [scrollbar~="\\~"]::-webkit-scrollbar-track{background-color:var(--scrollbar-track);}
@@ -43,7 +43,7 @@ exports[`scrollbar > should work in atributify mode 1`] = `
 
 exports[`scrollbar > var prefix 1`] = `
 "/* layer: shortcuts */
-.scrollbar{scrollbar-color:var(--my-custom-prefix-scrollbar-thumb) var(--my-custom-prefix-scrollbar-track);scrollbar-width:auto;--my-custom-prefix-scrollbar-track:#f5f5f5;--my-custom-prefix-scrollbar-thumb:#ddd;--my-custom-prefix-scrollbar-width:8px;--my-custom-prefix-scrollbar-height:8px;--my-custom-prefix-scrollbar-track-radius:4px;--my-custom-prefix-scrollbar-thumb-radius:4px;overflow:auto;}
+.scrollbar{--my-custom-prefix-scrollbar-track:#f5f5f5;--my-custom-prefix-scrollbar-thumb:#ddd;--my-custom-prefix-scrollbar-width:8px;--my-custom-prefix-scrollbar-height:8px;--my-custom-prefix-scrollbar-track-radius:4px;--my-custom-prefix-scrollbar-thumb-radius:4px;overflow:auto;}
 .scrollbar::-webkit-scrollbar{width:var(--my-custom-prefix-scrollbar-width);height:var(--my-custom-prefix-scrollbar-height);}
 .scrollbar::-webkit-scrollbar-thumb{background-color:var(--my-custom-prefix-scrollbar-thumb);}
 .scrollbar::-webkit-scrollbar-track{background-color:var(--my-custom-prefix-scrollbar-track);}

--- a/test/__snapshots__/index.test.ts.snap
+++ b/test/__snapshots__/index.test.ts.snap
@@ -1,22 +1,8 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
-exports[`scrollbar > custom value to unit 1`] = `
-"/* layer: default */
-.scrollbar-thumb-radius-2px{--scrollbar-thumb-radius:2px;}
-.scrollbar-w-1{--scrollbar-width:2px;}"
-`;
-
-exports[`scrollbar > preset set prefix 1`] = `
-"/* layer: default */
-.un-scrollbar{--scrollbar-track:#f5f5f5;--scrollbar-thumb:#ddd;--scrollbar-width:8px;--scrollbar-height:8px;--scrollbar-track-radius:4px;--scrollbar-thumb-radius:4px;overflow:auto;}
-.un-scrollbar::-webkit-scrollbar{width:var(--scrollbar-width);height:var(--scrollbar-height);}
-.un-scrollbar::-webkit-scrollbar-thumb{background-color:var(--scrollbar-thumb);}
-.un-scrollbar::-webkit-scrollbar-track{background-color:var(--scrollbar-track);}"
-`;
-
-exports[`scrollbar > presetUno prefix 1`] = `
+exports[`scrollbar > presetWind3 prefix 1`] = `
 "/* layer: shortcuts */
-.scrollbar{--scrollbar-track:#f5f5f5;--scrollbar-thumb:#ddd;--scrollbar-width:8px;--scrollbar-height:8px;--scrollbar-track-radius:4px;--scrollbar-thumb-radius:4px;overflow:auto;}
+.scrollbar{scrollbar-color:var(--scrollbar-thumb) var(--scrollbar-track);scrollbar-width:auto;--scrollbar-track:#f5f5f5;--scrollbar-thumb:#ddd;--scrollbar-width:8px;--scrollbar-height:8px;--scrollbar-track-radius:4px;--scrollbar-thumb-radius:4px;overflow:auto;}
 .scrollbar::-webkit-scrollbar{width:var(--scrollbar-width);height:var(--scrollbar-height);}
 .scrollbar::-webkit-scrollbar-thumb{background-color:var(--scrollbar-thumb);}
 .scrollbar::-webkit-scrollbar-track{background-color:var(--scrollbar-track);}"
@@ -24,20 +10,15 @@ exports[`scrollbar > presetUno prefix 1`] = `
 
 exports[`scrollbar > scrollbar 1`] = `
 "/* layer: shortcuts */
-.scrollbar{--scrollbar-track:#f5f5f5;--scrollbar-thumb:#ddd;--scrollbar-width:8px;--scrollbar-height:8px;--scrollbar-track-radius:4px;--scrollbar-thumb-radius:4px;overflow:auto;}
+.scrollbar{scrollbar-color:var(--scrollbar-thumb) var(--scrollbar-track);scrollbar-width:auto;--scrollbar-track:#f5f5f5;--scrollbar-thumb:#ddd;--scrollbar-width:8px;--scrollbar-height:8px;--scrollbar-track-radius:4px;--scrollbar-thumb-radius:4px;overflow:auto;}
 .scrollbar::-webkit-scrollbar{width:var(--scrollbar-width);height:var(--scrollbar-height);}
 .scrollbar::-webkit-scrollbar-thumb{background-color:var(--scrollbar-thumb);}
 .scrollbar::-webkit-scrollbar-track{background-color:var(--scrollbar-track);}
 .scrollbar-rounded::-webkit-scrollbar-thumb{border-radius:var(--scrollbar-thumb-radius);}
 .scrollbar-rounded::-webkit-scrollbar-track{border-radius:var(--scrollbar-track-radius);}
 /* layer: default */
-.scrollbar-radius-2{--scrollbar-track-radius:0.5rem;--scrollbar-thumb-radius:0.5rem;}
+.scrollbar-radius-2{--scrollbar-track-radius:2px;--scrollbar-thumb-radius:2px;}
 .scrollbar-w-4px{--scrollbar-width:4px;}"
-`;
-
-exports[`scrollbar > scrollbar color 1`] = `
-"/* layer: default */
-.scrollbar-track-color-red{--un-scrollbar-track-opacity:1;--scrollbar-track:rgb(248 113 113 / var(--un-scrollbar-track-opacity));}"
 `;
 
 exports[`scrollbar > scrollbar custom unit 1`] = `
@@ -47,7 +28,7 @@ exports[`scrollbar > scrollbar custom unit 1`] = `
 
 exports[`scrollbar > should work in atributify mode 1`] = `
 "/* layer: shortcuts */
-[scrollbar~="\\~"]{--scrollbar-track:#f5f5f5;--scrollbar-thumb:#ddd;--scrollbar-width:8px;--scrollbar-height:8px;--scrollbar-track-radius:4px;--scrollbar-thumb-radius:4px;overflow:auto;}
+[scrollbar~="\\~"]{scrollbar-color:var(--scrollbar-thumb) var(--scrollbar-track);scrollbar-width:auto;--scrollbar-track:#f5f5f5;--scrollbar-thumb:#ddd;--scrollbar-width:8px;--scrollbar-height:8px;--scrollbar-track-radius:4px;--scrollbar-thumb-radius:4px;overflow:auto;}
 [scrollbar~="\\~"]::-webkit-scrollbar{width:var(--scrollbar-width);height:var(--scrollbar-height);}
 [scrollbar~="\\~"]::-webkit-scrollbar-thumb{background-color:var(--scrollbar-thumb);}
 [scrollbar~="\\~"]::-webkit-scrollbar-track{background-color:var(--scrollbar-track);}
@@ -56,13 +37,13 @@ exports[`scrollbar > should work in atributify mode 1`] = `
 /* layer: default */
 .w-4px{width:4px;}
 .rounded{border-radius:0.25rem;}
-[scrollbar~="radius-2"]{--scrollbar-track-radius:0.5rem;--scrollbar-thumb-radius:0.5rem;}
+[scrollbar~="radius-2"]{--scrollbar-track-radius:2px;--scrollbar-thumb-radius:2px;}
 [scrollbar~="w-4px"]{--scrollbar-width:4px;}"
 `;
 
 exports[`scrollbar > var prefix 1`] = `
 "/* layer: shortcuts */
-.scrollbar{--my-custom-prefix-scrollbar-track:#f5f5f5;--my-custom-prefix-scrollbar-thumb:#ddd;--my-custom-prefix-scrollbar-width:8px;--my-custom-prefix-scrollbar-height:8px;--my-custom-prefix-scrollbar-track-radius:4px;--my-custom-prefix-scrollbar-thumb-radius:4px;overflow:auto;}
+.scrollbar{scrollbar-color:var(--my-custom-prefix-scrollbar-thumb) var(--my-custom-prefix-scrollbar-track);scrollbar-width:auto;--my-custom-prefix-scrollbar-track:#f5f5f5;--my-custom-prefix-scrollbar-thumb:#ddd;--my-custom-prefix-scrollbar-width:8px;--my-custom-prefix-scrollbar-height:8px;--my-custom-prefix-scrollbar-track-radius:4px;--my-custom-prefix-scrollbar-thumb-radius:4px;overflow:auto;}
 .scrollbar::-webkit-scrollbar{width:var(--my-custom-prefix-scrollbar-width);height:var(--my-custom-prefix-scrollbar-height);}
 .scrollbar::-webkit-scrollbar-thumb{background-color:var(--my-custom-prefix-scrollbar-thumb);}
 .scrollbar::-webkit-scrollbar-track{background-color:var(--my-custom-prefix-scrollbar-track);}
@@ -70,5 +51,5 @@ exports[`scrollbar > var prefix 1`] = `
 .scrollbar-rounded::-webkit-scrollbar-track{border-radius:var(--my-custom-prefix-scrollbar-track-radius);}
 /* layer: default */
 .scrollbar-thumb-radius-2px{--my-custom-prefix-scrollbar-thumb-radius:2px;}
-.scrollbar-w-1{--my-custom-prefix-scrollbar-width:0.25rem;}"
+.scrollbar-w-1{--my-custom-prefix-scrollbar-width:1px;}"
 `;

--- a/test/__snapshots__/index.test.ts.snap
+++ b/test/__snapshots__/index.test.ts.snap
@@ -21,6 +21,13 @@ exports[`scrollbar > scrollbar 1`] = `
 .scrollbar-w-4px{--scrollbar-width:4px;}"
 `;
 
+exports[`scrollbar > scrollbar color 1`] = `
+"/* layer: default */
+.scrollbar-thumb-color-red-800{--un-scrollbar-thumb-opacity:1;--scrollbar-thumb:rgb(153 27 27 / var(--un-scrollbar-thumb-opacity));}
+.scrollbar-track-color-red{--un-scrollbar-track-opacity:1;--scrollbar-track:rgb(248 113 113 / var(--un-scrollbar-track-opacity));}
+.scrollbar-track-op-80{--scrollbar-track-opacity:0.8;}"
+`;
+
 exports[`scrollbar > scrollbar custom unit 1`] = `
 "/* layer: default */
 .scrollbar-w-1px{--scrollbar-width:1px;}"

--- a/test/__snapshots__/index.test.ts.snap
+++ b/test/__snapshots__/index.test.ts.snap
@@ -17,7 +17,7 @@ exports[`scrollbar > scrollbar 1`] = `
 .scrollbar-rounded::-webkit-scrollbar-thumb{border-radius:var(--scrollbar-thumb-radius);}
 .scrollbar-rounded::-webkit-scrollbar-track{border-radius:var(--scrollbar-track-radius);}
 /* layer: default */
-.scrollbar-radius-2{--scrollbar-track-radius:2px;--scrollbar-thumb-radius:2px;}
+.scrollbar-radius-2{--scrollbar-track-radius:0.5rem;--scrollbar-thumb-radius:0.5rem;}
 .scrollbar-w-4px{--scrollbar-width:4px;}"
 `;
 
@@ -37,7 +37,7 @@ exports[`scrollbar > should work in atributify mode 1`] = `
 /* layer: default */
 .w-4px{width:4px;}
 .rounded{border-radius:0.25rem;}
-[scrollbar~="radius-2"]{--scrollbar-track-radius:2px;--scrollbar-thumb-radius:2px;}
+[scrollbar~="radius-2"]{--scrollbar-track-radius:0.5rem;--scrollbar-thumb-radius:0.5rem;}
 [scrollbar~="w-4px"]{--scrollbar-width:4px;}"
 `;
 
@@ -51,5 +51,5 @@ exports[`scrollbar > var prefix 1`] = `
 .scrollbar-rounded::-webkit-scrollbar-track{border-radius:var(--my-custom-prefix-scrollbar-track-radius);}
 /* layer: default */
 .scrollbar-thumb-radius-2px{--my-custom-prefix-scrollbar-thumb-radius:2px;}
-.scrollbar-w-1{--my-custom-prefix-scrollbar-width:1px;}"
+.scrollbar-w-1{--my-custom-prefix-scrollbar-width:0.25rem;}"
 `;

--- a/test/index-compatible.test.ts
+++ b/test/index-compatible.test.ts
@@ -3,21 +3,21 @@ import { describe, expect, it } from 'vitest'
 import { presetScrollbar } from '../src'
 
 describe('scrollbar (compatible)', async () => {
-  const generator = await createGenerator({
+  const uno = await createGenerator({
     presets: [
       presetScrollbar({
-        noCompatible: false,
+        compatible: false,
       }),
     ],
   })
 
   it('scrollbar-auto', async () => {
-    const { css } = await generator.generate('scrollbar')
+    const { css } = await uno.generate('scrollbar')
     expect(css).toMatchSnapshot()
   })
 
   it('scrollbar-thin', async () => {
-    const { css } = await generator.generate([
+    const { css } = await uno.generate([
       'scrollbar',
       'scrollbar-thin',
     ])
@@ -25,7 +25,7 @@ describe('scrollbar (compatible)', async () => {
   })
 
   it('scrollbar-none', async () => {
-    const { css } = await generator.generate([
+    const { css } = await uno.generate([
       'scrollbar',
       'scrollbar-none',
     ])

--- a/test/index-compatible.test.ts
+++ b/test/index-compatible.test.ts
@@ -6,7 +6,7 @@ describe('scrollbar (compatible)', async () => {
   const uno = await createGenerator({
     presets: [
       presetScrollbar({
-        compatible: false,
+        compatible: true,
       }),
     ],
   })

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -34,8 +34,6 @@ describe('scrollbar', async () => {
     ])
 
     expect(css).toMatchSnapshot()
-
-    // const { css: css2 } = await uno.generate('scrollbar-color-[var(--my-custom-prefix-scrollbar-thumb)_var(--my-custom-prefix-scrollbar-track)]')
   })
 
   it('scrollbar color', async () => {
@@ -44,12 +42,7 @@ describe('scrollbar', async () => {
       'scrollbar-track-op-80',
       'scrollbar-thumb-color-red-800',
     ])
-    expect(css).toMatchInlineSnapshot(`
-      "/* layer: default */
-      .scrollbar-thumb-color-red-800{--un-scrollbar-thumb-opacity:1;--scrollbar-thumb:rgb(153 27 27 / var(--un-scrollbar-thumb-opacity));}
-      .scrollbar-track-color-red{--un-scrollbar-track-opacity:1;--scrollbar-track:rgb(248 113 113 / var(--un-scrollbar-track-opacity));}
-      .scrollbar-track-op-80{--scrollbar-track-opacity:0.8;}"
-    `)
+    expect(css).toMatchSnapshot()
   })
 
   it('scrollbar custom unit', async () => {

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -86,7 +86,6 @@ describe('scrollbar', async () => {
       await enumerateSuggestions([
         'scrollbar-',
         'scrollbar-w-',
-        'sccrollbar-thumb-radius-',
         'scrollbar-radius-',
         'scrollbar-track-color-',
         'scrollbar-thumb-color-',
@@ -94,7 +93,6 @@ describe('scrollbar', async () => {
       ]),
     ).toMatchInlineSnapshot(`
       {
-        "sccrollbar-thumb-radius-": [],
         "scrollbar-": [
           "scrollbar-custom-property",
           "scrollbar-none",

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -1,12 +1,12 @@
 import { createAutocomplete } from '@unocss/autocomplete'
-import { createGenerator, presetAttributify, presetUno } from 'unocss'
+import { createGenerator, presetAttributify, presetWind3 } from 'unocss'
 import { describe, expect, it } from 'vitest'
 import { presetScrollbar } from '../src'
 
 describe('scrollbar', async () => {
-  const generator = await createGenerator({
+  const uno = await createGenerator({
     presets: [
-      presetUno({
+      presetWind3({
         preflight: false,
       }),
       presetAttributify(),
@@ -14,62 +14,53 @@ describe('scrollbar', async () => {
     ],
   })
 
-  const ac = createAutocomplete(generator)
+  const ac = createAutocomplete(uno)
 
   async function enumerateSuggestions(inputs: string[]) {
     return Object.fromEntries(await Promise.all(inputs.map(async input => [
       input,
-      (await ac.suggest(input)).slice(0, 10).join(' '),
+      (await ac.suggest(input)).slice(0, 10),
     ])))
   }
 
   it('scrollbar', async () => {
-    const { css } = await generator.generate([
+    const { css } = await uno.generate([
       'scrollbar',
       'scrollbar-rounded',
       'scrollbar-w-4px',
       'scrollbar-radius-2',
       'scrollbar-radius-track-4',
       'scrollbar-radius-thumb-4',
-    ].join(' '))
+    ])
 
     expect(css).toMatchSnapshot()
+
+    // const { css: css2 } = await uno.generate('scrollbar-color-[var(--my-custom-prefix-scrollbar-thumb)_var(--my-custom-prefix-scrollbar-track)]')
   })
 
   it('scrollbar color', async () => {
-    const { css } = await generator.generate([
+    const { css } = await uno.generate([
       'scrollbar-track-color-red',
-    ].join(' '))
-    expect(css).toMatchSnapshot()
+      'scrollbar-track-op-80',
+      'scrollbar-thumb-color-red-800',
+    ])
+    expect(css).toMatchInlineSnapshot(`
+      "/* layer: default */
+      .scrollbar-thumb-color-red-800{--un-scrollbar-thumb-opacity:1;--scrollbar-thumb:rgb(153 27 27 / var(--un-scrollbar-thumb-opacity));}
+      .scrollbar-track-color-red{--un-scrollbar-track-opacity:1;--scrollbar-track:rgb(248 113 113 / var(--un-scrollbar-track-opacity));}
+      .scrollbar-track-op-80{--scrollbar-track-opacity:0.8;}"
+    `)
   })
 
   it('scrollbar custom unit', async () => {
-    const { css } = await generator.generate([
+    const { css } = await uno.generate([
       'scrollbar-w-1px',
-    ].join(' '))
-    expect(css).toMatchSnapshot()
-  })
-
-  it('custom value to unit', async () => {
-    const generator = await createGenerator({
-      presets: [
-        presetUno({
-          preflight: false,
-        }),
-        presetScrollbar({
-          numberToUnit: value => `${value * 2}px`,
-        }),
-      ],
-    })
-    const { css } = await generator.generate([
-      'scrollbar-w-1',
-      'scrollbar-thumb-radius-2px',
-    ].join(' '))
+    ])
     expect(css).toMatchSnapshot()
   })
 
   it('should work in atributify mode', async () => {
-    const { css } = await generator.generate(`
+    const { css } = await uno.generate(`
 <div 
   scrollbar="~ rounded w-4px radius-2 radius-track-4 radius-thumb-4">
 </div>
@@ -78,9 +69,9 @@ describe('scrollbar', async () => {
   })
 
   it('var prefix', async () => {
-    const generator = await createGenerator({
+    const uno = await createGenerator({
       presets: [
-        presetUno({
+        presetWind3({
           preflight: false,
         }),
         presetScrollbar({
@@ -88,12 +79,12 @@ describe('scrollbar', async () => {
         }),
       ],
     })
-    const { css } = await generator.generate([
+    const { css } = await uno.generate([
       'scrollbar',
       'scrollbar-w-1',
       'scrollbar-thumb-radius-2px',
       'scrollbar-rounded',
-    ].join(' '))
+    ])
     expect(css).toMatchSnapshot()
   })
 
@@ -110,21 +101,87 @@ describe('scrollbar', async () => {
       ]),
     ).toMatchInlineSnapshot(`
       {
-        "sccrollbar-thumb-radius-": "",
-        "scrollbar-": "scrollbar-none scrollbar-rounded scrollbar-thin scrollbar-thumb-color-amber scrollbar-thumb-color-black scrollbar-thumb-color-blue scrollbar-thumb-color-bluegray scrollbar-thumb-color-blueGray scrollbar-thumb-color-coolgray scrollbar-thumb-color-coolGray",
-        "scrollbar-radius-": "scrollbar-radius-2 scrollbar-radius-0 scrollbar-radius-1 scrollbar-radius-3 scrollbar-radius-4 scrollbar-radius-5 scrollbar-radius-6 scrollbar-radius-8 scrollbar-radius-10 scrollbar-radius-12",
-        "scrollbar-thumb-": "scrollbar-thumb-radius-0 scrollbar-thumb-radius-1 scrollbar-thumb-radius-2 scrollbar-thumb-radius-3 scrollbar-thumb-radius-4 scrollbar-thumb-radius-5 scrollbar-thumb-radius-6 scrollbar-thumb-radius-8 scrollbar-thumb-radius-10 scrollbar-thumb-radius-12",
-        "scrollbar-thumb-color-": "scrollbar-thumb-color-amber scrollbar-thumb-color-black scrollbar-thumb-color-blue scrollbar-thumb-color-bluegray scrollbar-thumb-color-blueGray scrollbar-thumb-color-coolgray scrollbar-thumb-color-coolGray scrollbar-thumb-color-current scrollbar-thumb-color-cyan scrollbar-thumb-color-dark",
-        "scrollbar-track-color-": "scrollbar-track-color-amber scrollbar-track-color-black scrollbar-track-color-blue scrollbar-track-color-bluegray scrollbar-track-color-blueGray scrollbar-track-color-coolgray scrollbar-track-color-coolGray scrollbar-track-color-current scrollbar-track-color-cyan scrollbar-track-color-dark",
-        "scrollbar-w-": "scrollbar-w-4px scrollbar-w-1px scrollbar-w-0 scrollbar-w-1 scrollbar-w-2 scrollbar-w-3 scrollbar-w-4 scrollbar-w-5 scrollbar-w-6 scrollbar-w-8",
+        "sccrollbar-thumb-radius-": [],
+        "scrollbar-": [
+          "scrollbar-custom-property",
+          "scrollbar-none",
+          "scrollbar-rounded",
+          "scrollbar-thin",
+          "scrollbar-thumb-color-amber",
+          "scrollbar-thumb-color-black",
+          "scrollbar-thumb-color-blue",
+          "scrollbar-thumb-color-bluegray",
+          "scrollbar-thumb-color-blueGray",
+          "scrollbar-thumb-color-coolgray",
+        ],
+        "scrollbar-radius-": [
+          "scrollbar-radius-2",
+          "scrollbar-radius-0",
+          "scrollbar-radius-1",
+          "scrollbar-radius-3",
+          "scrollbar-radius-4",
+          "scrollbar-radius-5",
+          "scrollbar-radius-6",
+          "scrollbar-radius-8",
+          "scrollbar-radius-10",
+          "scrollbar-radius-12",
+        ],
+        "scrollbar-thumb-": [
+          "scrollbar-thumb-color-amber",
+          "scrollbar-thumb-color-black",
+          "scrollbar-thumb-color-blue",
+          "scrollbar-thumb-color-bluegray",
+          "scrollbar-thumb-color-blueGray",
+          "scrollbar-thumb-color-coolgray",
+          "scrollbar-thumb-color-coolGray",
+          "scrollbar-thumb-color-current",
+          "scrollbar-thumb-color-cyan",
+          "scrollbar-thumb-color-dark",
+        ],
+        "scrollbar-thumb-color-": [
+          "scrollbar-thumb-color-amber",
+          "scrollbar-thumb-color-black",
+          "scrollbar-thumb-color-blue",
+          "scrollbar-thumb-color-bluegray",
+          "scrollbar-thumb-color-blueGray",
+          "scrollbar-thumb-color-coolgray",
+          "scrollbar-thumb-color-coolGray",
+          "scrollbar-thumb-color-current",
+          "scrollbar-thumb-color-cyan",
+          "scrollbar-thumb-color-dark",
+        ],
+        "scrollbar-track-color-": [
+          "scrollbar-track-color-amber",
+          "scrollbar-track-color-black",
+          "scrollbar-track-color-blue",
+          "scrollbar-track-color-bluegray",
+          "scrollbar-track-color-blueGray",
+          "scrollbar-track-color-coolgray",
+          "scrollbar-track-color-coolGray",
+          "scrollbar-track-color-current",
+          "scrollbar-track-color-cyan",
+          "scrollbar-track-color-dark",
+        ],
+        "scrollbar-w-": [
+          "scrollbar-w-4px",
+          "scrollbar-w-1px",
+          "scrollbar-w-0",
+          "scrollbar-w-1",
+          "scrollbar-w-2",
+          "scrollbar-w-3",
+          "scrollbar-w-4",
+          "scrollbar-w-5",
+          "scrollbar-w-6",
+          "scrollbar-w-8",
+        ],
       }
     `)
   })
 
-  it('presetUno prefix', async () => {
-    const generator = await createGenerator({
+  it('presetWind3 prefix', async () => {
+    const uno = await createGenerator({
       presets: [
-        presetUno({
+        presetWind3({
           preflight: false,
           prefix: 'tw-',
         }),
@@ -133,24 +190,8 @@ describe('scrollbar', async () => {
     })
     const {
       css,
-    } = await generator.generate([
+    } = await uno.generate([
       'scrollbar',
-    ])
-    expect(css).toMatchSnapshot()
-  })
-
-  it('preset set prefix', async () => {
-    const generator = await createGenerator({
-      presets: [
-        presetScrollbar({
-          prefix: 'un-',
-        }),
-      ],
-    })
-    const {
-      css,
-    } = await generator.generate([
-      'un-scrollbar',
     ])
     expect(css).toMatchSnapshot()
   })

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,7 +4,6 @@
     "lib": ["esnext"],
     "module": "esnext",
     "moduleResolution": "bundler",
-    "verbatimModuleSyntax": true,
     "paths": {
       "unocss-preset-scrollbar": [
         "./src/index.ts"
@@ -13,6 +12,7 @@
     "resolveJsonModule": true,
     "strict": true,
     "esModuleInterop": true,
+    "verbatimModuleSyntax": true,
     "skipDefaultLibCheck": true,
     "skipLibCheck": true
   },


### PR DESCRIPTION
> [!WARNING]
> This PR changes the following:

- Optimized previous rules to better conform to Unocss syntax and speed up parsing.

- Deprecated `numberToUnit`. Unocss has built-in number unit parsing; I recommend aligning it with `presetWind3`and `presetWind4`. If unit conversion is needed, handle it in other steps, such as `postprocess`.

- Deprecated `prefix`. Prefixes are not compatible with shortcuts in sccollbar. sccollbar is already quite special, and I believe prefixes are sufficient; they are redundant and should be removed.

- Rename `noCompatible` to `compatible`

- Updated test snapshots.

fixes #20, fixes #15, fixes #16